### PR TITLE
[JEP-223] [JEP-224] Proof of concept

### DIFF
--- a/core/src/main/java/hudson/model/ManagementLink.java
+++ b/core/src/main/java/hudson/model/ManagementLink.java
@@ -119,6 +119,16 @@ public abstract class ManagementLink implements ExtensionPoint, Action {
     }
 
     /**
+     * Whether to show this link on /manage
+     *
+     * @return true if and only if the link should be shown
+     */
+    public boolean isShowLink() {
+        final Permission requiredPermission = getRequiredPermission();
+        return requiredPermission == null || Jenkins.get().hasPermission(requiredPermission);
+    }
+
+    /**
      * Define if the rendered link will use the default GET method or POST.
      * @return true if POST must be used
      * @see RequirePOST

--- a/core/src/main/java/hudson/security/GlobalSecurityConfiguration.java
+++ b/core/src/main/java/hudson/security/GlobalSecurityConfiguration.java
@@ -27,6 +27,7 @@ import com.google.common.base.Predicate;
 import hudson.BulkChange;
 import hudson.Extension;
 import hudson.Functions;
+import hudson.RestrictedSince;
 import hudson.markup.MarkupFormatter;
 import hudson.model.Descriptor;
 import hudson.model.Descriptor.FormException;
@@ -184,9 +185,11 @@ public class GlobalSecurityConfiguration extends ManagementLink implements Descr
         return Jenkins.ADMINISTER;
     }
 
-    public static Predicate<GlobalConfigurationCategory> FILTER = new Predicate<GlobalConfigurationCategory>() {
-        public boolean apply(GlobalConfigurationCategory input) {
-            return input instanceof GlobalConfigurationCategory.Security;
+    @Restricted(NoExternalUse.class)
+    @RestrictedSince("TODO")
+    public static Predicate<Descriptor> FILTER = new Predicate<Descriptor>() {
+        public boolean apply(Descriptor input) {
+            return input.getCategory() instanceof GlobalConfigurationCategory.Security;
         }
     };
 

--- a/core/src/main/java/jenkins/management/ConfigureLink.java
+++ b/core/src/main/java/jenkins/management/ConfigureLink.java
@@ -52,10 +52,10 @@ public class ConfigureLink extends ManagementLink {
         return Messages.ConfigureLink_Description();
     }
 
-    @CheckForNull
     @Override
-    public Permission getRequiredPermission() {
-        return Jenkins.MANAGE;
+    public boolean isShowLink() {
+        final Jenkins j = Jenkins.get();
+        return j.hasPermission(Jenkins.MANAGE) || j.hasPermission(Jenkins.SYSTEM_READ);
     }
 
     @Override

--- a/core/src/main/java/jenkins/management/SystemInfoLink.java
+++ b/core/src/main/java/jenkins/management/SystemInfoLink.java
@@ -26,7 +26,11 @@ package jenkins.management;
 
 import hudson.Extension;
 import hudson.model.ManagementLink;
+import hudson.security.Permission;
+import jenkins.model.Jenkins;
 import org.jenkinsci.Symbol;
+
+import javax.annotation.CheckForNull;
 
 /**
  * @author <a href="mailto:nicolas.deloof@gmail.com">Nicolas De Loof</a>
@@ -46,6 +50,12 @@ public class SystemInfoLink extends ManagementLink {
     @Override
     public String getDescription() {
         return Messages.SystemInfoLink_Description();
+    }
+
+    @CheckForNull
+    @Override
+    public Permission getRequiredPermission() {
+        return Jenkins.SYSTEM_READ;
     }
 
     @Override

--- a/core/src/main/java/jenkins/model/Jenkins.java
+++ b/core/src/main/java/jenkins/model/Jenkins.java
@@ -2200,7 +2200,8 @@ public class Jenkins extends AbstractCIBase implements DirectlyModifiableTopLeve
      * @since 2.64
      */
     public List<AdministrativeMonitor> getActiveAdministrativeMonitors() {
-        if (!Jenkins.get().hasPermission(ADMINISTER)) {
+        if (!Jenkins.get().hasPermission(SYSTEM_READ)) {
+            // half-assed SystemRead support, needs specific support in admin monitors for any user actions
             return Collections.emptyList();
         }
         return administrativeMonitors.stream().filter(m -> {
@@ -5259,6 +5260,18 @@ public class Jenkins extends AbstractCIBase implements DirectlyModifiableTopLeve
             SystemProperties.getBoolean("jenkins.security.ManagePermission"),
             new PermissionScope[]{PermissionScope.JENKINS});
 
+    /**
+     * Allows read-only access to large parts of the system configuration.
+     *
+     * When combined with {@link #MANAGE}, it is expected that everything is shown as if only {@link #SYSTEM_READ} was granted,
+     * but that options editable by users with {@link #MANAGE} only remain editable.
+     */
+    @Restricted(Beta.class)
+    public static final Permission SYSTEM_READ = new Permission(PERMISSIONS, "SystemRead",
+            Messages._Jenkins_SystemRead_Description(),
+            ADMINISTER,
+            SystemProperties.getBoolean("jenkins.security.SystemReadPermission"),
+            new PermissionScope[]{PermissionScope.JENKINS});
 
     public static final Permission READ = new Permission(PERMISSIONS,"Read",Messages._Hudson_ReadPermission_Description(),Permission.READ,PermissionScope.JENKINS);
     public static final Permission RUN_SCRIPTS = new Permission(PERMISSIONS, "RunScripts", Messages._Hudson_RunScriptsPermission_Description(),ADMINISTER,PermissionScope.JENKINS);

--- a/core/src/main/java/jenkins/tools/GlobalToolConfiguration.java
+++ b/core/src/main/java/jenkins/tools/GlobalToolConfiguration.java
@@ -101,9 +101,9 @@ public class GlobalToolConfiguration extends ManagementLink {
         return d.configure(req, js);
     }
 
-    public static Predicate<GlobalConfigurationCategory> FILTER = new Predicate<GlobalConfigurationCategory>() {
-        public boolean apply(GlobalConfigurationCategory input) {
-            return input instanceof ToolConfigurationCategory;
+    public static Predicate<Descriptor> FILTER = new Predicate<Descriptor>() {
+        public boolean apply(Descriptor input) {
+            return input.getCategory() instanceof ToolConfigurationCategory;
         }
     };
 

--- a/core/src/main/resources/hudson/model/Messages.properties
+++ b/core/src/main/resources/hudson/model/Messages.properties
@@ -166,6 +166,8 @@ Hudson.AdministerPermission.Description=\
 Jenkins.Manage.Description=\
   This permission grants the ability to configure parts of the overall system configuration \
   that are not expected to impact the overall stability and security of the system.
+Jenkins.SystemRead.Description=\
+  This permission grants read-only access to large parts of the overall system configuration.
 Hudson.ReadPermission.Description=\
   The read permission is necessary for viewing almost all pages of Jenkins. \
   This permission is useful when you don\u2019t want unauthenticated users to see \

--- a/core/src/main/resources/hudson/slaves/SlaveComputer/threadDump.jelly
+++ b/core/src/main/resources/hudson/slaves/SlaveComputer/threadDump.jelly
@@ -29,17 +29,15 @@ THE SOFTWARE.
 -->
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
-  <l:layout title="${%title(it.displayName)}">
+  <l:layout title="${%title(it.displayName)}" permission="app.SYSTEM_READ">
     <st:include page="sidepanel.jelly" />
 
     <l:main-panel>
-      <l:isAdmin>
-        <h1>${%Thread Dump}</h1>
-        <j:forEach var="t" items="${it.getThreadDump().entrySet()}">
-          <h2>${t.key}</h2>
-          <pre>${t.value}</pre>
-        </j:forEach>
-      </l:isAdmin>
+      <h1>${%Thread Dump}</h1>
+      <j:forEach var="t" items="${it.getThreadDump().entrySet()}">
+        <h2>${t.key}</h2>
+        <pre>${t.value}</pre>
+      </j:forEach>
     </l:main-panel>
   </l:layout>
 </j:jelly>

--- a/core/src/main/resources/jenkins/model/Jenkins/configure.jelly
+++ b/core/src/main/resources/jenkins/model/Jenkins/configure.jelly
@@ -27,7 +27,8 @@ THE SOFTWARE.
 -->
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
-<l:layout norefresh="true" permission="${it.MANAGE}" title="${%Configure System}">
+<l:layout norefresh="true" title="${%Configure System}">
+  ${h.checkAnyPermission(it, app.MANAGE, app.SYSTEM_READ)}
   <st:include page="sidepanel.jelly" />
   <f:breadcrumb-config-outline />
   <l:main-panel>
@@ -45,7 +46,9 @@ THE SOFTWARE.
       </f:entry>
 
       <!-- global configuration from everyone -->
-      <j:forEach var="descriptor" items="${h.getSortedDescriptorsForGlobalConfigUnclassified()}">
+      <j:forEach var="descriptor" items="${h.getSortedDescriptorsForGlobalConfigUnclassifiedReadable()}">
+        <j:set var="editable" value="${h.getSortedDescriptorsForGlobalConfigUnclassified()}"/>
+        <j:set var="readOnlyMode" value="${!editable.contains(descriptor)}" />
         <j:set var="instance" value="${descriptor}" /><!-- this makes the <f:textbox field=.../> work -->
         <f:rowSet name="${descriptor.jsonSafeClassName}">
           <st:include page="${descriptor.globalConfigPage}" from="${descriptor}" />

--- a/core/src/main/resources/jenkins/model/Jenkins/manage.jelly
+++ b/core/src/main/resources/jenkins/model/Jenkins/manage.jelly
@@ -27,7 +27,8 @@ THE SOFTWARE.
 -->
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
-<l:layout title="${%Manage Jenkins}" xmlns:local="local" permission="${app.MANAGE}">
+<l:layout title="${%Manage Jenkins}" xmlns:local="local">
+  ${h.checkAnyPermission(it, app.MANAGE, app.SYSTEM_READ)}
 
   <l:header>
      <link rel="stylesheet" href="${resURL}/bootstrap/css/bootstrap.min.css" type="text/css" />
@@ -49,7 +50,7 @@ THE SOFTWARE.
     </div>
 
     <j:forEach var="m" items="${it.managementLinks}">
-      <l:hasPermission permission="${m.requiredPermission}">
+      <j:if test="${m.isShowLink()}">
         <j:set var="icon" value="${m.iconClassName != null ? m.iconClassName : m.iconFileName}" />
         <j:if test="${icon!=null}">
           <div class="manage-option">
@@ -90,7 +91,7 @@ THE SOFTWARE.
           </j:choose>
           </div>
         </j:if>
-      </l:hasPermission>
+      </j:if>
     </j:forEach>
 
   </l:main-panel>

--- a/core/src/main/resources/jenkins/model/Jenkins/systemInfo.jelly
+++ b/core/src/main/resources/jenkins/model/Jenkins/systemInfo.jelly
@@ -27,7 +27,7 @@ THE SOFTWARE.
 -->
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
-  <l:layout permission="${app.ADMINISTER}" title="${%System Information}">
+  <l:layout permission="${app.SYSTEM_READ}" title="${%System Information}">
     <st:include page="sidepanel.jelly" />
     <l:main-panel>
         <h1>${%System Properties}</h1>

--- a/core/src/main/resources/jenkins/model/Jenkins/threadDump.jelly
+++ b/core/src/main/resources/jenkins/model/Jenkins/threadDump.jelly
@@ -27,7 +27,7 @@ THE SOFTWARE.
 -->
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
-  <l:layout permission="${app.ADMINISTER}" title="${%Thread dump}">
+  <l:layout permission="${app.SYSTEM_READ}" title="${%Thread dump}">
     <st:include page="sidepanel.jelly" />
 
     <l:main-panel>

--- a/core/src/main/resources/lib/form/checkbox.jelly
+++ b/core/src/main/resources/lib/form/checkbox.jelly
@@ -68,6 +68,7 @@ THE SOFTWARE.
          title="${attrs.tooltip}"
          onclick="${attrs.readonly=='true' ? 'return false;' : attrs.onclick}" id="${attrs.id}" class="${attrs.class} ${attrs.negative!=null ? 'negative' : null} ${attrs.checkUrl!=null?'validated':''}"
          checkUrl="${attrs.checkUrl}" checkDependsOn="${attrs.checkDependsOn}" json="${attrs.json}"
+         disabled="${readOnlyMode ? 'true' : null}"
          checked="${value ? 'true' : null}"/>
   <j:if test="${attrs.title!=null}">
     <label class="attach-previous"

--- a/core/src/main/resources/lib/form/entry.jelly
+++ b/core/src/main/resources/lib/form/entry.jelly
@@ -72,6 +72,7 @@ THE SOFTWARE.
     <td class="setting-leftspace"><st:nbsp/></td>
     <td class="setting-name">
       <j:out value="${escapeEntryTitleAndDescription ? h.escape(attrs.title) : attrs.title}" />
+      (${readOnlyMode})
     </td>
     <td class="setting-main">
       <d:invokeBody />


### PR DESCRIPTION
This is a PoC combining JEP-223 and JEP-224.

It is based on the "minimal JEP-223" https://github.com/jenkinsci/jenkins/pull/4501 and adds rudimentary `SYSTEM_READ` support.

Challenges:

* `ManagementLink` visibility needs to support Manage-only, SystemRead-only, or either.
* Views and actions needs a more flexible permission check; `permission="???"` doesn't cut it when it should be shown for either Manage or SystemRead. Right now done through `${h.checkAnyPermission(it, app.MANAGE, app.SYSTEM_READ)}` for views, and TBD for actions. **This also means that the _Manage Jenkins_ link won't currently appear for SystemRead users, despite it being otherwise functional**.
* Separate "readable" and "editable" descriptors for the global configuration.
* Support different presentation of descriptors when a user has both MANAGE and SYSTEM_READ, approximated by the label suffix (I'm lazy and this is a PoC)

## Screenshots

### Permissions

![Screenshot 2020-02-15 at 14 27 58](https://user-images.githubusercontent.com/1831569/74589858-635a2000-5009-11ea-9a6f-6e5cdef0bcb5.png)


### admin

![Screenshot 2020-02-15 at 15 30 47](https://user-images.githubusercontent.com/1831569/74589812-fe9ec580-5008-11ea-8770-13b79b14d277.png)
![Screenshot 2020-02-15 at 15 30 53](https://user-images.githubusercontent.com/1831569/74589814-00688900-5009-11ea-9ed1-4dfb5c701cd5.png)

### manager

(Same as in https://github.com/jenkinsci/jenkins/pull/4501; only Configure System and pages that don't require special permissions anyway)

![Screenshot 2020-02-15 at 15 30 30](https://user-images.githubusercontent.com/1831569/74589816-0a8a8780-5009-11ea-8aef-67dbd125e7df.png)
![Screenshot 2020-02-15 at 15 30 36](https://user-images.githubusercontent.com/1831569/74589818-0c544b00-5009-11ea-8b18-ba38276de9b1.png)

### System-reader

Has admin monitors and a privileged view, trivial to add others (e.g. manager's), but demonstrating the independent access.

![Screenshot 2020-02-15 at 15 30 12](https://user-images.githubusercontent.com/1831569/74589839-39086280-5009-11ea-943f-4c316d61bfce.png)
![Screenshot 2020-02-15 at 15 30 19](https://user-images.githubusercontent.com/1831569/74589840-3b6abc80-5009-11ea-82c0-0a7bc5909da9.png)

### manager + reader

Has admin monitors, the union set of ManagementLinks, sees all options on the Configure Jenkins form, but can only edit some.

![Screenshot 2020-02-15 at 15 29 40](https://user-images.githubusercontent.com/1831569/74589852-5b9a7b80-5009-11ea-934f-6472234f0626.png)
![Screenshot 2020-02-15 at 15 29 50](https://user-images.githubusercontent.com/1831569/74589854-5ccba880-5009-11ea-9ccf-d0fb0860e8ce.png)

### user

New: Has Overall/Read but none of the relevant permissions used above.

![Screenshot 2020-02-15 at 16 07 16](https://user-images.githubusercontent.com/1831569/74590282-550e0300-500d-11ea-9547-e3a541d6d06f.png)
![Screenshot 2020-02-15 at 16 07 20](https://user-images.githubusercontent.com/1831569/74590283-56d7c680-500d-11ea-8e3c-7f5df972c196.png)
