### PR TITLE
404 simple page for the resource domain

### DIFF
--- a/core/src/main/java/jenkins/security/ResourceDomainFilter.java
+++ b/core/src/main/java/jenkins/security/ResourceDomainFilter.java
@@ -24,6 +24,7 @@
 
 package jenkins.security;
 
+import hudson.Functions;
 import hudson.init.InitMilestone;
 import hudson.init.Initializer;
 import hudson.util.PluginServletFilter;
@@ -70,7 +71,7 @@ public class ResourceDomainFilter implements Filter {
             HttpServletResponse httpServletResponse = (HttpServletResponse) servletResponse;
             if (ResourceDomainConfiguration.isResourceRequest(httpServletRequest)) {
                 String path = httpServletRequest.getPathInfo();
-                if (!path.startsWith("/" + ResourceDomainRootAction.URL + "/") && !ALLOWED_PATHS.contains(path)) {
+                if (!path.startsWith("/" + ResourceDomainRootAction.URL + "/") && !ALLOWED_PATHS.contains(path) && !isImageResource(path)) {
                     LOGGER.fine(() -> "Rejecting request to " + httpServletRequest.getRequestURL() + " from " + httpServletRequest.getRemoteAddr() + " on resource domain");
                     httpServletResponse.sendError(404, ERROR_RESPONSE);
                     return;
@@ -84,6 +85,13 @@ public class ResourceDomainFilter implements Filter {
     @Override
     public void init(FilterConfig filterConfig) throws ServletException {
 
+    }
+
+    private boolean isImageResource(String path) {
+        if (path.startsWith(Functions.getResourcePath() + "/images")) {
+            return true;
+        }
+        return false;
     }
 
     @Override

--- a/core/src/main/java/jenkins/security/ResourceDomainRootAction.java
+++ b/core/src/main/java/jenkins/security/ResourceDomainRootAction.java
@@ -74,6 +74,8 @@ import org.springframework.security.core.userdetails.UsernameNotFoundException;
 @Restricted(NoExternalUse.class)
 public class ResourceDomainRootAction implements UnprotectedRootAction {
 
+    private static final String RESOURCE_DOMAIN_ROOT_ACTION_ERROR = "jenkins.security.ResourceDomainRootAction.error";
+
     private static final Logger LOGGER = Logger.getLogger(ResourceDomainRootAction.class.getName());
 
     public static final String URL = "static-files";
@@ -104,12 +106,14 @@ public class ResourceDomainRootAction implements UnprotectedRootAction {
         if (ResourceDomainConfiguration.isResourceRequest(req)) {
             rsp.sendError(404, ResourceDomainFilter.ERROR_RESPONSE);
         } else {
+            req.setAttribute(RESOURCE_DOMAIN_ROOT_ACTION_ERROR, true);
             rsp.sendError(404, "Cannot handle requests to this URL unless on Jenkins resource URL.");
         }
     }
 
     public Object getDynamic(String id, StaplerRequest req, StaplerResponse rsp) throws Exception {
         if (!ResourceDomainConfiguration.isResourceRequest(req)) {
+            req.setAttribute(RESOURCE_DOMAIN_ROOT_ACTION_ERROR, true);
             rsp.sendError(404, "Cannot handle requests to this URL unless on Jenkins resource URL.");
             return null;
         }

--- a/core/src/main/resources/jenkins/model/Jenkins/_404.jelly
+++ b/core/src/main/resources/jenkins/model/Jenkins/_404.jelly
@@ -34,20 +34,22 @@ THE SOFTWARE.
         <l:header />
         <l:main-panel>
             <h1 style="text-align: center">
-                <img src="${imagesURL}/rage.png" height="179" width="154"/> <span style="font-size:50px"><st:nbsp/>${%Oops!}</span>
+                <img src="${imagesURL}/rage.svg" height="179" width="154"/> <span style="font-size:50px"><st:nbsp/>${%Oops!}</span>
             </h1>
             <div id="error-description" style="text-align: center">
                 <h2>${%title(javax.servlet.error.message)}</h2>
-                <p>
-                    <j:choose>
-                        <j:when test="${app.useSecurity}">
-                            ${%noAccess}
-                        </j:when>
-                        <j:otherwise>
-                            ${%notFound}
-                        </j:otherwise>
-                    </j:choose>
-                </p>
+                <j:if test="${!request.getAttribute('jenkins.security.ResourceDomainRootAction.error')}">
+	                  <p>
+	                      <j:choose>
+	                          <j:when test="${app.useSecurity}">
+		                            ${%noAccess}
+		                        </j:when>
+		                        <j:otherwise>
+		                            ${%notFound}
+		                        </j:otherwise>
+		                    </j:choose>
+                    </p>
+                </j:if>
             </div>
         </l:main-panel>
     </l:layout>

--- a/core/src/main/resources/jenkins/model/Jenkins/_404_simple.jelly
+++ b/core/src/main/resources/jenkins/model/Jenkins/_404_simple.jelly
@@ -1,0 +1,53 @@
+<!--
+The MIT License
+
+Copyright (c) 2021 Daniel Beck
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+-->
+
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout"  xmlns:x="jelly:xml">
+    <!--
+      This is the page designated by web.xml to handle 404 errors on the resource domain.
+      We do not have access to all the javascript and css resources here, so render a simple page
+    -->
+<l:view contentType="text/html;charset=UTF-8">
+<st:setHeader name="Expires" value="0" />
+<st:setHeader name="Cache-Control" value="no-cache,no-store,must-revalidate" />
+<st:setHeader name="X-Hudson-Theme" value="default" />
+<st:setHeader name="Referrer-Policy" value="same-origin" />
+<st:setHeader name="Cross-Origin-Opener-Policy" value="same-origin" />
+<x:doctype name="html" />
+<st:statusCode value="${response.getStatus()}" />
+${request.session.setAttribute('from', request.getAttribute('javax.servlet.error.request_uri'))}
+<html>
+  <title>${%Not found}</title>
+  <body style="font-family: system-ui, sans-serif">
+   <h1 style="text-align: center">
+     <img src="${imagesURL}/rage.svg" height="179" width="154" style="vertical-align: middle"/> <span style="font-size:50px"><st:nbsp/>${%Oops!}</span>
+   </h1>
+   <div style="text-align: center">
+	   <h2>${%title(javax.servlet.error.message)}</h2>
+	   <a href="${h.inferHudsonURL(request)}">${%Back to dashboard}</a>
+   </div>
+  </body>
+</html>
+</l:view>
+</j:jelly>

--- a/core/src/main/resources/jenkins/model/Jenkins/_404_simple.properties
+++ b/core/src/main/resources/jenkins/model/Jenkins/_404_simple.properties
@@ -1,0 +1,1 @@
+title = Error: {0}


### PR DESCRIPTION
the resource domain has no access to the static resources like javascript and css. Open the images in the filter so we can at least show an image.
Do not show the hint about not found or permission when accessing the static-files url from the regular domain.

<!-- Comment:
A great PR typically begins with the line below.
Replace XXXXX with the numeric part of the issue ID you created in Jira.
Note that if you want your changes backported into LTS, you need to create a Jira issue. See https://www.jenkins.io/download/lts/#backporting-process for more information.
-->

See [JENKINS-XXXXX](https://issues.jenkins.io/browse/JENKINS-XXXXX).

<!-- Comment:
If the issue is not fully described in Jira, add more information here (justification, pull request links, etc.).

 * We do not require Jira issues for minor improvements.
 * Bug fixes should have a Jira issue to facilitate the backporting process.
 * Major new features should have a Jira issue.
-->

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Proposed changelog entries

- Entry 1: Issue, human-readable text
- […]

<!-- Comment:
The changelog entry should be in the imperative mood; e.g., write "do this"/"return that" rather than "does this"/"returns that".
For examples, see: https://www.jenkins.io/changelog/
-->

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [ ] The Jira issue, if it exists, is well-described.
- [ ] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)).
  - Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [ ] There is automated testing or an explanation as to why this change has no tests.
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [ ] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [ ] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [ ] For new APIs and extension points, there is a link to at least one consumer.

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/core-pr-reviewers.
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`:

- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).
